### PR TITLE
Feature/computer rules

### DIFF
--- a/NuAppFirewall/NuAppFirewall.xcodeproj/project.pbxproj
+++ b/NuAppFirewall/NuAppFirewall.xcodeproj/project.pbxproj
@@ -764,8 +764,8 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 14.7;
-				MARKETING_VERSION = 1.0;
+				MACOSX_DEPLOYMENT_TARGET = 12.4;
+				MARKETING_VERSION = 2.0;
 				NEW_SETTING = "";
 				PRODUCT_BUNDLE_IDENTIFIER = com.nufuturo.nuappfirewall.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -807,8 +807,8 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 14.7;
-				MARKETING_VERSION = 1.0;
+				MACOSX_DEPLOYMENT_TARGET = 12.4;
+				MARKETING_VERSION = 2.0;
 				NEW_SETTING = "";
 				PRODUCT_BUNDLE_IDENTIFIER = com.nufuturo.nuappfirewall.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/NuAppFirewall/NuAppFirewall/Src/Consts/Consts.swift
+++ b/NuAppFirewall/NuAppFirewall/Src/Consts/Consts.swift
@@ -29,4 +29,3 @@ struct Consts {
         return appSupportURL
     }()
 }
-

--- a/NuAppFirewall/NuAppFirewall/Src/Logic/RulesManager.swift
+++ b/NuAppFirewall/NuAppFirewall/Src/Logic/RulesManager.swift
@@ -75,6 +75,13 @@ class RulesManager {
     func getRule(bundleID: String, appPath: String, url: String, host: String, ip: String, port: String) -> Rule? {
         var matchedRules: [Rule] = []
         
+        matchedRules.append(contentsOf: findRules(app: Consts.any, url: url, host: host, ip: ip, port: port, fallbackToSubpath: false))
+             
+        let computerRule = selectRule(from: matchedRules, url, host, ip, port, preferBlock: true)
+        guard computerRule == nil else {
+            return computerRule
+        }
+        
         matchedRules.append(contentsOf: findRules(app: bundleID, url: url, host: host, ip: ip, port: port, fallbackToSubpath: false))
         let bundleRule = selectRule(from: matchedRules, url, host, ip, port, preferBlock: true)
         guard bundleRule == nil else {

--- a/NuAppFirewall/NuAppFirewallTests/Consts/TestConstants.swift
+++ b/NuAppFirewall/NuAppFirewallTests/Consts/TestConstants.swift
@@ -14,8 +14,9 @@ enum TestConstants {
     static let ip = "123.123.123"
     static let port = "443"
     static let unknown = "unknown"
+    static let any = "any"
     static let actionAllow = Consts.verdictAllow
     static let actionBlock = Consts.verdictBlock
-    static let ruleDataCombinationsCount = 48
+    static let ruleDataCombinationsCount = 64
     static let flowDataCombinationsCount = 48
 }

--- a/NuAppFirewall/NuAppFirewallTests/Controller/FlowManagerMockTests.swift
+++ b/NuAppFirewall/NuAppFirewallTests/Controller/FlowManagerMockTests.swift
@@ -52,14 +52,14 @@ class FlowManagerMockTests: XCTestCase {
                 
                 let testInfo = "RuleData(action: \(ruleData.action), app: \(ruleData.app), endpoint: \(ruleData.endpoint), port: \(ruleData.port)) | FlowData(url: \(flowData.url), host: \(flowData.host), ip: \(flowData.ip), port: \(flowData.port), application: \(flowData.app))"
                 
-                let isApplicationMatch = rule.application == flowData.app || flowData.app.contains(rule.application)
+                let isApplicationMatch = rule.application == flowData.app || flowData.app.contains(rule.application) || rule.application == TestConstants.any
 
                 let isEndpointMatch = rule.endpoint == flowMock.url ||
                                       rule.endpoint == flowMock.host ||
                                       rule.endpoint == flowMock.ip ||
-                                      rule.endpoint == Consts.any
+                                      rule.endpoint == TestConstants.any
 
-                let isPortMatch = rule.port == flowData.port || rule.port == Consts.any
+                let isPortMatch = rule.port == flowData.port || rule.port == TestConstants.any
 
                 if isApplicationMatch && isEndpointMatch && isPortMatch {
                     let expectedVerdict = rule.action == TestConstants.actionBlock ? TestConstants.actionBlock : TestConstants.actionAllow

--- a/NuAppFirewall/NuAppFirewallTests/TestHelpers/TestDataFactory.swift
+++ b/NuAppFirewall/NuAppFirewallTests/TestHelpers/TestDataFactory.swift
@@ -8,7 +8,7 @@
 class TestDataFactory {
     
     static func generateRuleData(
-        apps: [String] = [TestConstants.appPath, TestConstants.appSubpath, TestConstants.bundleID],
+        apps: [String] = [TestConstants.appPath, TestConstants.appSubpath, TestConstants.bundleID, TestConstants.any],
         endpoints: [String] = [Consts.any, TestConstants.url, TestConstants.host, TestConstants.ip],
         actions: [String] = [Consts.verdictAllow, Consts.verdictBlock],
         ports: [String] = [Consts.any, TestConstants.port]


### PR DESCRIPTION
# Pull Request: Adiciona validação de regras gerais no computador independente de aplicação

Este PR Adiciona a validação de regras gerais do computador que executam independente de aplicação, além dos testes de unidade para exercitar as novas combinações. Com isso, temos a árvore completa implementada:

![Aplicação da Regra (6)](https://github.com/user-attachments/assets/9a2cc6dd-af83-420c-9741-a2ecb5119ecb)

### Código Principal:

- **Novas formas de validação de regras:** foi adicionada a possibilidade de aplicar regrais gerais no computador. Agora é possível bloquear portas e endpoints separadamente ou bloquear uma combinação de porta e endpoint. Por exemplo, bloquear a porta responsável pelo protocolo FTP como segue:

<img width="279" alt="Captura de Tela 2025-02-20 às 11 18 15" src="https://github.com/user-attachments/assets/dc3639de-ae1d-45f1-9c16-9c01c582bc4a" />


<img width="586" alt="Captura de Tela 2025-02-20 às 11 18 41" src="https://github.com/user-attachments/assets/44b12db4-6165-4d04-885d-182ddae351e7" />


- **Testes para a novas combinações possíveis:** As combinações nos testes foram aumentadas para cobrir as novas possibilidades de aplicação de regras.
